### PR TITLE
Fix document class warning

### DIFF
--- a/HOWTO.cls
+++ b/HOWTO.cls
@@ -1,5 +1,5 @@
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesClass{pkg}[2024/09/21 HOWTO Class]
+\ProvidesClass{HOWTO}[2024/09/21 HOWTO Class]
 
 \LoadClass[a4paper]{book}
 


### PR DESCRIPTION
موقع بیلد، xelatex گیر می‌داد که documentclass ای که فایل `HOWTO.cls` معرفی می‌کنه، `pkg` هست که باید `HOWTO` باشه:
```
LaTeX Warning: You have requested document class 'HOWTO',                             
               but the document class provides 'pkg'.
```